### PR TITLE
Proper quoting for argument passed by xargs

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ In code:
 #!/bin/bash
 rome download --platform iOS # download missing frameworks (or copy from local cache)
 carthage bootstrap --platform iOS --cache-builds # build dependencies missing a .version file or that where not found in the cache
-rome list --missing --platform iOS | awk '{print $1}' | xargs rome upload --platform iOS # upload what is missing
+rome list --missing --platform iOS | awk '{print $1}' | xargs -I {} rome upload "{}" --platform iOS # upload what is missing
 ```
 
 #### List workflow
@@ -175,8 +175,8 @@ In code:
 ```sh
 #!/bin/bash
 rome download --platform iOS # download missing frameworks (or copy from local cache)
-rome list --missing --platform iOS | awk '{print $1}' | xargs carthage bootstrap --platform iOS --cache-builds # list what is missing and update/build if needed
-rome list --missing --platform iOS | awk '{print $1}' | xargs rome upload --platform iOS # upload what is missing
+rome list --missing --platform iOS | awk '{print $1}' | xargs -I {} carthage bootstrap "{}" --platform iOS --cache-builds # list what is missing and update/build if needed
+rome list --missing --platform iOS | awk '{print $1}' | xargs -I {} rome upload "{}" --platform iOS # upload what is missing
 ```
 
 If no frameworks are missing, the `awk` pipe to `carthage` will fail and the rest of the command will not be executed. This avoids rebuilding all dependencies or uploading artifacts already present in the cache.
@@ -752,7 +752,7 @@ ResearchKit 1.4.1 : -tvOS -watchOS
 Forwarding a list of missing frameworks to Carthage for building:
 
 ```bash
-$ rome list --missing --platform ios | awk '{print $1}' | xargs carthage build --platform ios
+$ rome list --missing --platform ios | awk '{print $1}' | xargs -I {} carthage build "{}" --platform ios
 *** xcodebuild output can be found in ...
 ```
 


### PR DESCRIPTION
`rome upload` doesn't work when the GitHub repository name is with special symbols (e.g. `-` or `.`).  An example of an error if the argument isn't quoted:

```
$ rome list --missing --platform iOS | awk '{print $1}' | xargs rome upload --platform iOS -v
Invalid argument `Bolts-Swift'

Usage: rome COMMAND [--romefile PATH] [-v]
```

Proof that it works: 
```
$ rome list --missing --platform iOS | awk '{print $1}' | xargs -I {} rome upload "{}" --platform iOS -v
16:50:24 2020-01-19 - Started uploading .Bolts-Swift.version to: Bolts-Swift/.Bolts-Swift.version-1.5.0
16:50:25 2020-01-19 - Uploaded .Bolts-Swift.version to: Bolts-Swift/.Bolts-Swift.version-1.5.0
16:50:26 2020-01-19 - Starting to zip: Carthage/Build/iOS/Lottie.framework
16:50:26 2020-01-19 - Started uploading Lottie to: lottie-ios/iOS/Lottie.framework-2.5.3.zip
16:50:45 2020-01-19 - Uploaded Lottie to: lottie-ios/iOS/Lottie.framework-2.5.3.zip
16:50:45 2020-01-19 - Starting to zip: Carthage/Build/iOS/Lottie.framework.dSYM
16:50:45 2020-01-19 - Started uploading Lottie.dSYM to: lottie-ios/iOS/Lottie.framework.dSYM-2.5.3.zip
16:50:59 2020-01-19 - Uploaded Lottie.dSYM to: lottie-ios/iOS/Lottie.framework.dSYM-2.5.3.zip
16:50:59 2020-01-19 - Starting to zip: Carthage/Build/iOS/C51D4BA0-8D58-3CC5-BD3E-B8229F1173E2.bcsymbolmap
16:50:59 2020-01-19 - Starting to zip: Carthage/Build/iOS/FBE17C07-5689-3726-99AF-EF8BD396976F.bcsymbolmap
16:50:59 2020-01-19 - Started uploading Lottie.C51D4BA0-8D58-3CC5-BD3E-B8229F1173E2.bcsymbolmap to: lottie-ios/iOS/C51D4BA0-8D58-3CC5-BD3E-B8229F1173E2.bcsymbolmap-2.5.3.zip
16:51:00 2020-01-19 - Uploaded Lottie.C51D4BA0-8D58-3CC5-BD3E-B8229F1173E2.bcsymbolmap to: lottie-ios/iOS/C51D4BA0-8D58-3CC5-BD3E-B8229F1173E2.bcsymbolmap-2.5.3.zip
16:51:00 2020-01-19 - Started uploading Lottie.FBE17C07-5689-3726-99AF-EF8BD396976F.bcsymbolmap to: lottie-ios/iOS/FBE17C07-5689-3726-99AF-EF8BD396976F.bcsymbolmap-2.5.3.zip
16:51:00 2020-01-19 - Uploaded Lottie.FBE17C07-5689-3726-99AF-EF8BD396976F.bcsymbolmap to: lottie-ios/iOS/FBE17C07-5689-3726-99AF-EF8BD396976F.bcsymbolmap-2.5.3.zip
16:51:00 2020-01-19 - Started uploading .lottie-ios.version to: lottie-ios/.lottie-ios.version-2.5.3
16:51:01 2020-01-19 - Uploaded .lottie-ios.version to: lottie-ios/.lottie-ios.version-2.5.3
16:51:02 2020-01-19 - Starting to zip: Carthage/Build/iOS/OnePasswordExtension.framework
16:51:02 2020-01-19 - Started uploading OnePasswordExtension to: onepassword-extension/iOS/OnePasswordExtension.framework-bcc4cc97fed9a6e73fa204f2e61138e353cb3ef7.zip
16:51:04 2020-01-19 - Uploaded OnePasswordExtension to: onepassword-extension/iOS/OnePasswordExtension.framework-bcc4cc97fed9a6e73fa204f2e61138e353cb3ef7.zip
16:51:04 2020-01-19 - Starting to zip: Carthage/Build/iOS/OnePasswordExtension.framework.dSYM
16:51:04 2020-01-19 - Started uploading OnePasswordExtension.dSYM to: onepassword-extension/iOS/OnePasswordExtension.framework.dSYM-bcc4cc97fed9a6e73fa204f2e61138e353cb3ef7.zip
16:51:18 2020-01-19 - Uploaded OnePasswordExtension.dSYM to: onepassword-extension/iOS/OnePasswordExtension.framework.dSYM-bcc4cc97fed9a6e73fa204f2e61138e353cb3ef7.zip
16:51:18 2020-01-19 - Starting to zip: Carthage/Build/iOS/5AE26058-6947-35AF-91D4-11BB2A4402D1.bcsymbolmap
16:51:18 2020-01-19 - Starting to zip: Carthage/Build/iOS/37C1EDFE-EF3E-3153-90CB-A65CBD43B8A9.bcsymbolmap
16:51:18 2020-01-19 - Started uploading OnePasswordExtension.5AE26058-6947-35AF-91D4-11BB2A4402D1.bcsymbolmap to: onepassword-extension/iOS/5AE26058-6947-35AF-91D4-11BB2A4402D1.bcsymbolmap-bcc4cc97fed9a6e73fa204f2e61138e353cb3ef7.zip
16:51:19 2020-01-19 - Uploaded OnePasswordExtension.5AE26058-6947-35AF-91D4-11BB2A4402D1.bcsymbolmap to: onepassword-extension/iOS/5AE26058-6947-35AF-91D4-11BB2A4402D1.bcsymbolmap-bcc4cc97fed9a6e73fa204f2e61138e353cb3ef7.zip
16:51:19 2020-01-19 - Started uploading OnePasswordExtension.37C1EDFE-EF3E-3153-90CB-A65CBD43B8A9.bcsymbolmap to: onepassword-extension/iOS/37C1EDFE-EF3E-3153-90CB-A65CBD43B8A9.bcsymbolmap-bcc4cc97fed9a6e73fa204f2e61138e353cb3ef7.zip
16:51:20 2020-01-19 - Uploaded OnePasswordExtension.37C1EDFE-EF3E-3153-90CB-A65CBD43B8A9.bcsymbolmap to: onepassword-extension/iOS/37C1EDFE-EF3E-3153-90CB-A65CBD43B8A9.bcsymbolmap-bcc4cc97fed9a6e73fa204f2e61138e353cb3ef7.zip
16:51:20 2020-01-19 - Started uploading .onepassword-extension.version to: onepassword-extension/.onepassword-extension.version-bcc4cc97fed9a6e73fa204f2e61138e353cb3ef7
16:51:20 2020-01-19 - Uploaded .onepassword-extension.version to: onepassword-extension/.onepassword-extension.version-bcc4cc97fed9a6e73fa204f2e61138e353cb3ef7
16:51:21 2020-01-19 - Starting to zip: Carthage/Build/iOS/Realm.framework
16:51:21 2020-01-19 - Started uploading Realm to: realm-cocoa/iOS/Realm.framework-v3.21.0.zip
