### PR TITLE
Reduce verbosity by hiding delete errors

### DIFF
--- a/src/Network/AWS/Utils.hs
+++ b/src/Network/AWS/Utils.hs
@@ -97,9 +97,7 @@ authFromCredentilas profile credentials = AWS.Auth <$> authEnv
     AWS.AuthEnv
       <$> (AWS.AccessKey <$> accessKeyId)
       <*> (AWS.Sensitive . AWS.SecretKey <$> secretAccessKey)
-      <*> (   (Just . AWS.Sensitive . AWS.SessionToken <$> sessionToken)
-          <|> pure Nothing
-          )
+      <*> ((Just . AWS.Sensitive . AWS.SessionToken <$> sessionToken) <|> pure Nothing)
       <*> ((T.readEither =<< T.unpack <$> expirationDate) <|> pure Nothing)
 
 regionOf :: T.Text -> ConfigFile -> Either String AWS.Region
@@ -115,65 +113,47 @@ endPointOf profile = parseURL <=< lookupValue profile "endpoint" . asIni
  where
   parseURL s = if T.null s
     then Left "Failed reading: Failure parsing Endpoint from empty string"
-    else
-      maybeToEither "Failed reading: Endpoint is not a valid URL"
-      $ importURL
-      . T.unpack
-      $ s
+    else maybeToEither "Failed reading: Endpoint is not a valid URL" $ importURL . T.unpack $ s
 
-getPropertyFromCredentials
-  :: T.Text -> T.Text -> CredentialsFile -> Either String T.Text
-getPropertyFromCredentials profile property =
-  lookupValue profile property . asIni
+getPropertyFromCredentials :: T.Text -> T.Text -> CredentialsFile -> Either String T.Text
+getPropertyFromCredentials profile property = lookupValue profile property . asIni
 
 getPropertyFromConfig :: T.Text -> T.Text -> ConfigFile -> Either String T.Text
 getPropertyFromConfig profile property = lookupValue profile property . asIni
 
 sourceProfileOf :: T.Text -> ConfigFile -> Either String T.Text
-sourceProfileOf profile configFile =
-  getPropertyFromConfig finalProfile key configFile
-    `withError` const (missingKeyError key profile)
+sourceProfileOf profile configFile = getPropertyFromConfig finalProfile key configFile
+  `withError` const (missingKeyError key profile)
  where
-  key = "source_profile"
-  finalProfile =
-    if profile == "default" then profile else T.pack "profile " <> profile
+  key          = "source_profile"
+  finalProfile = if profile == "default" then profile else T.pack "profile " <> profile
 
 roleARNOf :: T.Text -> ConfigFile -> Either String T.Text
-roleARNOf profile configFile =
-  getPropertyFromConfig finalProfile key configFile
-    `withError` const (missingKeyError key profile)
+roleARNOf profile configFile = getPropertyFromConfig finalProfile key configFile
+  `withError` const (missingKeyError key profile)
  where
-  key = "role_arn"
-  finalProfile =
-    if profile == "default" then profile else T.pack "profile " <> profile
+  key          = "role_arn"
+  finalProfile = if profile == "default" then profile else T.pack "profile " <> profile
 
 accessKeyIdOf :: T.Text -> CredentialsFile -> Either String T.Text
-accessKeyIdOf profile credFile =
-  getPropertyFromCredentials profile key credFile
-    `withError` const (missingKeyError key profile)
+accessKeyIdOf profile credFile = getPropertyFromCredentials profile key credFile
+  `withError` const (missingKeyError key profile)
   where key = "aws_access_key_id"
 
 missingKeyError :: T.Text -> T.Text -> String
-missingKeyError key profile =
-  "Could not find key `"
-    ++ T.unpack key
-    ++ "` for profile `"
-    ++ T.unpack profile
-    ++ "`"
+missingKeyError key profile = "Could not find key `" ++ T.unpack key ++ "` for profile `" ++ T.unpack profile ++ "`"
 
 withError :: Either a b -> (a -> c) -> Either c b
 withError = flip mapLeft
 
 secretAccessKeyOf :: T.Text -> CredentialsFile -> Either String T.Text
-secretAccessKeyOf profile credFile =
-  getPropertyFromCredentials profile key credFile
-    `withError` const (missingKeyError key profile)
+secretAccessKeyOf profile credFile = getPropertyFromCredentials profile key credFile
+  `withError` const (missingKeyError key profile)
   where key = "aws_secret_access_key"
 
 sessionTokenOf :: T.Text -> CredentialsFile -> Either String T.Text
-sessionTokenOf profile credFile =
-  getPropertyFromCredentials profile key credFile
-    `withError` const (missingKeyError key profile)
+sessionTokenOf profile credFile = getPropertyFromCredentials profile key credFile
+  `withError` const (missingKeyError key profile)
   where key = "aws_session_token"
 
 expirationOf :: T.Text -> CredentialsFile -> Either String T.Text

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -6,76 +6,74 @@
 module Utils where
 
 import qualified Codec.Archive.Zip             as Zip
-import           Configuration                            ( carthageArtifactsBuildDirectoryForPlatform )
-import           Control.Arrow                            ( left )
+import           Configuration                  ( carthageArtifactsBuildDirectoryForPlatform )
+import           Control.Arrow                  ( left )
 import           Control.Exception             as E
-                                                          ( try )
-import           Control.Lens                      hiding ( List )
-import           Control.Monad.Catch
+                                                ( try )
+import           Control.Lens            hiding ( List )
 import           Control.Monad.Except
-import           Control.Monad.Trans.Resource             ( MonadUnliftIO
-                                                          , runResourceT
-                                                          )
+import           Control.Monad.Trans.Resource   ( MonadUnliftIO
+                                                , runResourceT
+                                                )
 import           Data.Aeson
 import           Data.Aeson.Types
 import qualified Data.ByteString.Char8         as BS
 import qualified Data.ByteString.Lazy          as LBS
 import           Data.Carthage.Cartfile
 import           Data.Carthage.TargetPlatform
-import           Data.Char                                ( isNumber )
+import           Data.Char                      ( isNumber )
 import qualified Data.Conduit                  as C
-                                                          ( runConduit
-                                                          , (.|)
-                                                          )
+                                                ( runConduit
+                                                , (.|)
+                                                )
 import qualified Data.Conduit.Binary           as C
-                                                          ( sinkFile
-                                                          , sourceLbs
-                                                          )
-import           Data.Function                            ( on )
+                                                ( sinkFile
+                                                , sourceLbs
+                                                )
+import           Data.Function                  ( on )
 import           Data.List
 import qualified Data.Map.Strict               as M
-import           Data.Maybe                               ( fromJust
-                                                          , fromMaybe
-                                                          )
+import           Data.Maybe                     ( fromJust
+                                                , fromMaybe
+                                                )
 import           Data.Romefile
 import qualified Data.Text                     as T
 import           Data.Text.Encoding
 import qualified Data.Text.IO                  as T
 import           Data.Time
 import qualified Network.AWS                   as AWS
-                                                          ( Error
-                                                          , ErrorMessage(..)
-                                                          , serviceMessage
-                                                          , _ServiceError
-                                                          )
+                                                ( Error
+                                                , ErrorMessage(..)
+                                                , serviceMessage
+                                                , _ServiceError
+                                                )
 import qualified Network.AWS.Data.Text         as AWS
-                                                          ( showText )
+                                                ( showText )
 
 import           Network.HTTP.Conduit          as HTTP
 import           Network.HTTP.Types.Header     as HTTP
-                                                          ( hUserAgent )
-import           Numeric                                  ( showFFloat )
-import           System.Directory                         ( createDirectoryIfMissing
-                                                          , doesDirectoryExist
-                                                          , doesFileExist
-                                                          , getHomeDirectory
-                                                          , removeFile
-                                                          )
-import           System.FilePath                          ( addTrailingPathSeparator
-                                                          , dropFileName
-                                                          , normalise
-                                                          , (</>)
-                                                          )
-import           System.IO.Error                          ( isDoesNotExistError )
-import           System.Path.NameManip                    ( absolute_path
-                                                          , guess_dotdot
-                                                          )
-import           Text.Read                                ( readMaybe )
+                                                ( hUserAgent )
+import           Numeric                        ( showFFloat )
+import           System.Directory               ( createDirectoryIfMissing
+                                                , doesDirectoryExist
+                                                , doesFileExist
+                                                , getHomeDirectory
+                                                , removeFile
+                                                )
+import           System.FilePath                ( addTrailingPathSeparator
+                                                , dropFileName
+                                                , normalise
+                                                , (</>)
+                                                )
+import           System.Path.NameManip          ( absolute_path
+                                                , guess_dotdot
+                                                )
+import           Text.Read                      ( readMaybe )
 import qualified Turtle
 import           Types
-import           Xcode.DWARF                              ( DwarfUUID
-                                                          , bcsymbolmapNameFrom
-                                                          )
+import           Xcode.DWARF                    ( DwarfUUID
+                                                , bcsymbolmapNameFrom
+                                                )
 
 
 
@@ -561,11 +559,8 @@ deleteFile
   -> m ()
 deleteFile path verbose = do
   let sayFunc = if verbose then sayLnWithTime else sayLn
-  liftIO $ removeFile path `catch` handleError sayFunc
+  liftIO $ removeFile path
   when verbose $ liftIO . sayFunc $ "Deleted: " <> path
- where
-  handleError f e | isDoesNotExistError e = f $ "Error: no such file " <> path
-                  | otherwise             = throwM e
 
 
 


### PR DESCRIPTION
Delete errors are still logged when `-v` is specified