### PR TITLE
Remove query parameters from repo name parsed from binary Cartfile entry

### DIFF
--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -213,7 +213,7 @@ gitRepoNameFromCartfileEntry (CartfileEntry GitHub (Location l) _) =
 gitRepoNameFromCartfileEntry (CartfileEntry Git (Location l) _) =
   ProjectName . T.unpack . T.replace ".git" "" . last . splitWithSeparator '/' . T.pack $ l
 gitRepoNameFromCartfileEntry (CartfileEntry Binary (Location l) _) =
-  ProjectName . T.unpack . T.replace ".json" "" . last . splitWithSeparator '/' . T.pack $ l
+  ProjectName . T.unpack . head . T.splitOn ".json" . last . splitWithSeparator '/' . T.pack $ l
 
 
 


### PR DESCRIPTION
In case a Binary entry in the Cartfile has a query parameter, Rome will consider this query parameters as part of the repo name used in the cache, which results in this binary entry not being able to be cached, because the version file doesn't have query parameters in the filename.

To resolve this issue I changed the `gitRepoNameFromCartfileEntry` method to not only replace the `.json` file extension, but to split on it and use the head.

**Reproduction Steps:**

1. `carthage bootstrap` using the Cartfile.resolved from below
2. `rome upload`
3. Clear the local Carthage/Build folder
4. `rome download`

**Expected behavior:**

All dependencies are being fetched from the cache.

**Observed behavior:**

Rome cannot find the version file, because it looks for the wrong file name.

**Problematic Romefile**

_Note:_ Using `tealium-carthage-plcrashreporter?_cb=2` in the Romefile will result in the framework and dSYM being uploaded and downloaded, but the version file will not be uploaded or downloaded. Using `tealium-carthage-plcrashreporter` in the Romefile won't work, because then executing `rome list --missing` will output `tealium-carthage-plcrashreporter?_cb=2 1.4.0`

```yml
cache:
  local: ~/Library/Caches/Rome

repositoryMap:
- tealium-carthage-plcrashreporter?_cb=2:
  - name: TealiumCrashReporteriOS
- tealium-swift:
  - name: TealiumAppData
  - name: TealiumAttribution
  - name: TealiumAutotracking
  - name: TealiumCollect
  - name: TealiumConnectivity
  - name: TealiumConsentManager
  - name: TealiumCore
  - name: TealiumCrash
  - name: TealiumDelegate
  - name: TealiumDeviceData
  - name: TealiumDispatchQueue
  - name: TealiumLifecycle
  - name: TealiumLocation
  - name: TealiumLogger
  - name: TealiumPersistentData
  - name: TealiumRemoteCommands
  - name: TealiumTagManagement
  - name: TealiumVisitorService
  - name: TealiumVolatileData
```

**Problematic Cartfile.resolved**

```
binary "https://tags.tiqcdn.com/dle/tealiummobile/tealium-ios-carthage/tealium-carthage-plcrashreporter.json?_cb=2" "1.4.0"
github "tealium/tealium-swift" "1.9.4"
```

**Rome version:** 0.23.2.63 - Romam uno die non fuisse conditam.
**OS and version:** macOS 10.15.4 (19E266)

**Additional information:**

* Problem started happening recently, didn't happen in an older version of Rome: No
* Problem can be reliably reproduced, doesn't happen randomly: Yes
* Problem happens with all Romefile / Cartfile.resolved and projects, not only some files or projects: No