### PR TITLE
Update to XCFrameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Trusted by:
 
 <a href="https://www.sharecare.com"><img src="https://www.hmnads.com/wp-content/uploads/2015/06/Sharecare-logo.png" alt="sharecare" height="90px"/></a> 
 <a href="https://line.me"><img src="https://vignette.wikia.nocookie.net/starwars/images/b/b1/LINE_Corp_logo.png/revision/latest?cb=20170923181031" alt="linecorp" height="90px"/></a> 
+<a href="https://www.workday.com"><img src="https://i.imgur.com/q29Fyzq.png" alt="sharecare" height="90px"/></a> 
 <a href="https://www.daimler-tss.com"><img src="https://www.hdm-stuttgart.de/unternehmen/karrieremarktplatz/anmeldung/aussteller_uploads/99/dLlVePMVtu191516349018.png" alt="DaimlerTSS" height="90px"/></a> <a href="https://www.mozilla.com"><img src="https://upload.wikimedia.org/wikipedia/commons/thumb/d/d2/Mozilla_logo.svg/2000px-Mozilla_logo.svg.png" alt="Mozilla" height="90px"/></a> <a href="https://www.brave.com"><img src="https://brave.com/wp-content/uploads/2019/03/brave-logo-1.png" alt="Brave" height="90px"/></a> <a href="https://labs.spotify.com/2019/10/23/when-in-rome-how-spotify-halved-build-times-with-just-one-script/"><img src="https://storage.googleapis.com/pr-newsroom-wp/1/2018/11/Spotify_Logo_CMYK_Green.png" alt="Spotify" height="90px"/></a>
 
 

--- a/src/Engine/Downloading.hs
+++ b/src/Engine/Downloading.hs
@@ -59,97 +59,6 @@ getVersionFileFromEngine enginePath projectNameAndVersion tmpDir = do
   versionFileRemotePath = remoteVersionFilePath projectNameAndVersion
 
 
--- | Retrieves a bcsymbolmap using the engine
-getBcsymbolmapWithEngine
-  :: FilePath -- ^ The `FilePath` to the engine
-  -> InvertedRepositoryMap -- ^ The map used to resolve from a `FrameworkVersion` to the path of the dSYM in the cache
-  -> FrameworkVersion -- ^ The `FrameworkVersion` identifying the dSYM
-  -> TargetPlatform -- ^ The `TargetPlatform` to limit the operation to
-  -> DwarfUUID -- ^ The UUID of the bcsymbolmap
-  -> FilePath -- ^ A temporary intermediate directory
-  -> ExceptT String (ReaderT (CachePrefix, Bool, UUID.UUID) IO) LBS.ByteString
-getBcsymbolmapWithEngine enginePath reverseRomeMap (FrameworkVersion f@(Framework fwn _ _) version) platform dwarfUUID tmpDir
-  = do
-    (CachePrefix prefix, verbose, uuid) <- ask
-    let finalRemoteBcsymbolmaploadPath = prefix </> remoteBcSymbolmapUploadPath
-    mapExceptT (withReaderT (const (verbose, uuid)))
-      $ getArtifactFromEngine enginePath finalRemoteBcsymbolmaploadPath symbolmapName tmpDir
- where
-  remoteBcSymbolmapUploadPath = remoteBcsymbolmapPath dwarfUUID platform reverseRomeMap f version
-  symbolmapName               = fwn <> "." <> bcsymbolmapNameFrom dwarfUUID
-
-
--- | Retrieves a dSYM using the engine
-getDSYMFromEngine
-  :: FilePath -- ^ The `FilePath` to the engine
-  -> InvertedRepositoryMap -- ^ The map used to resolve from a `FrameworkVersion` to the path of the dSYM in the cache
-  -> FrameworkVersion -- ^ The `FrameworkVersion` identifying the dSYM
-  -> TargetPlatform -- ^ The `TargetPlatform` to limit the operation to
-  -> FilePath -- ^ A temporary intermediate directory
-  -> ExceptT String (ReaderT (CachePrefix, Bool, UUID.UUID) IO) LBS.ByteString
-getDSYMFromEngine enginePath reverseRomeMap (FrameworkVersion f@(Framework fwn _ _) version) platform tmpDir = do
-  (CachePrefix prefix, verbose, uuid) <- ask
-  let finalRemoteDSYMUploadPath = prefix </> remoteDSYMUploadPath
-  mapExceptT (withReaderT (const (verbose, uuid)))
-    $ getArtifactFromEngine enginePath finalRemoteDSYMUploadPath dSYMName tmpDir
- where
-  remoteDSYMUploadPath = remoteDsymPath platform reverseRomeMap f version
-  dSYMName             = fwn <> ".dSYM"
-
-
--- | Retrieves a bcsymbolmap using the engine and unzip the contents
-getAndUnzipBcsymbolmapWithEngine
-  :: FilePath -- ^ The `FilePath` to the engine
-  -> InvertedRepositoryMap -- ^ The map used to resolve from a `FrameworkVersion` to the path of the dSYM in the cache
-  -> FrameworkVersion -- ^ The `FrameworkVersion` identifying the dSYM
-  -> TargetPlatform -- ^ The `TargetPlatform` to limit the operation to
-  -> DwarfUUID -- ^ The UUID of the bcsymbolmap
-  -> FilePath -- ^ A temporary intermediate directory
-  -> ExceptT String (ReaderT (CachePrefix, Bool, UUID.UUID) IO) ()
-getAndUnzipBcsymbolmapWithEngine enginePath reverseRomeMap fVersion@(FrameworkVersion f@(Framework fwn _ fwps) version) platform dwarfUUID tmpDir
-  = when (platform `elem` fwps) $ do
-    (_, verbose, _) <- ask
-    let sayFunc       = if verbose then sayLnWithTime else sayLn
-    let symbolmapName = fwn <> "." <> bcsymbolmapNameFrom dwarfUUID
-    binary <- getBcsymbolmapWithEngine enginePath reverseRomeMap fVersion platform dwarfUUID tmpDir
-    liftIO $ deleteFile (bcsymbolmapPath dwarfUUID) verbose
-      `catch` (\e ->
-        if isDoesNotExistError e then when verbose $ sayFunc ("Error :" <> displayException e) else throw e)
-    unzipBinary binary symbolmapName (bcsymbolmapZipName dwarfUUID) verbose
- where
-  platformBuildDirectory = carthageArtifactsBuildDirectoryForPlatform platform f
-  bcsymbolmapZipName d = bcsymbolmapArchiveName d version
-  bcsymbolmapPath d = platformBuildDirectory </> bcsymbolmapNameFrom d
-
-
--- | Retrieves all the bcsymbolmap files using the engine and unzip the contents
-getAndUnzipBcsymbolmapsWithEngine'
-  :: FilePath -- ^ The `FilePath` to the engine
-  -> InvertedRepositoryMap -- ^ The map used to resolve from a `FrameworkVersion` to the path of the dSYM in the cache
-  -> FrameworkVersion -- ^ The `FrameworkVersion` identifying the Framework
-  -> TargetPlatform -- ^ The `TargetPlatform` to limit the operation to
-  -> FilePath -- ^ A temporary intermediate directory
-  -> ExceptT DWARFOperationError (ReaderT (CachePrefix, Bool, UUID.UUID) IO) ()
-getAndUnzipBcsymbolmapsWithEngine' enginePath reverseRomeMap fVersion@(FrameworkVersion f@(Framework fwn _ fwps) _) platform tmpDir
-  = when (platform `elem` fwps) $ do
-
-    dwarfUUIDs               <- withExceptT (const ErrorGettingDwarfUUIDs) $ dwarfUUIDsFrom (frameworkDirectory </> fwn)
-    eitherDwarfUUIDsOrSucces <- forM
-      dwarfUUIDs
-      (\dwarfUUID -> lift $ runExceptT
-        ( withExceptT (\e -> (dwarfUUID, e))
-        $ getAndUnzipBcsymbolmapWithEngine enginePath reverseRomeMap fVersion platform dwarfUUID tmpDir
-        )
-      )
-
-    let failedUUIDsAndErrors = lefts eitherDwarfUUIDsOrSucces
-    unless (null failedUUIDsAndErrors) $ throwError $ FailedDwarfUUIDs failedUUIDsAndErrors
- where
-  frameworkNameWithFrameworkExtension = appendFrameworkExtensionTo f
-  platformBuildDirectory              = carthageArtifactsBuildDirectoryForPlatform platform f
-  frameworkDirectory                  = platformBuildDirectory </> frameworkNameWithFrameworkExtension
-
-
 -- | Retrieves a Framework using the engine and unzip the contents
 getAndUnzipFrameworkWithEngine
   :: FilePath -- ^ The `FilePath` to the engine
@@ -170,26 +79,10 @@ getAndUnzipFrameworkWithEngine enginePath reverseRomeMap fVersion@(FrameworkVers
   frameworkExecutablePath = frameworkBuildBundleForPlatform platform f </> fwn
 
 
--- | Retrieves a dSYM using the engine and unzip the contents
-getAndUnzipDSYMWithEngine
-  :: FilePath -- ^ The `FilePath` to the engine
-  -> InvertedRepositoryMap -- ^ The map used to resolve from a `FrameworkVersion` to the path of the dSYM in the cache
-  -> FrameworkVersion -- ^ The `FrameworkVersion` identifying the dSYM
-  -> TargetPlatform -- ^ The `TargetPlatform` to limit the operation to
-  -> FilePath -- ^ A temporary intermediate directory
-  -> ExceptT String (ReaderT (CachePrefix, Bool, UUID.UUID) IO) ()
-getAndUnzipDSYMWithEngine enginePath reverseRomeMap fVersion@(FrameworkVersion f@(Framework fwn _ fwps) version) platform tmpDir
-  = when (platform `elem` fwps) $ do
-    (_, verbose, _) <- ask
-    dSYMBinary      <- getDSYMFromEngine enginePath reverseRomeMap fVersion platform tmpDir
-    deleteDSYMDirectory fVersion platform verbose
-    unzipBinary dSYMBinary fwn dSYMZipName verbose
-  where dSYMZipName = dSYMArchiveName f version
-
 -- | Retrieves an artifact using the engine
 getArtifactFromEngine
   :: FilePath -- ^ The `FilePath` to the engine
-  -> FilePath -- ^ The remote path 
+  -> FilePath -- ^ The remote path
   -> String -- ^ A colloquial name for the artifact
   -> FilePath -- ^ A temporary intermediate directory
   -> ExceptT String (ReaderT (Bool, UUID.UUID) IO) LBS.ByteString
@@ -201,6 +94,7 @@ getArtifactFromEngine enginePath remotePath artifactName tmpDir = do
   case eitherArtifact of
     Left  e              -> throwError $ "Error: could not download " <> artifactName <> " : " <> show e
     Right artifactBinary -> return artifactBinary
+
 
 -- | Downloads an artifact stored at a given path using the engine
 downloadBinaryWithEngine

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -160,9 +160,9 @@ splitWithSeparator a = T.split (== a)
 
 
 
--- | Appends the string ".framework" to a `Framework`'s name.
+-- | Appends the string ".xcframework" to a `Framework`'s name.
 appendFrameworkExtensionTo :: Framework -> String
-appendFrameworkExtensionTo (Framework a _ _) = a ++ ".framework"
+appendFrameworkExtensionTo (Framework a _ _) = a ++ ".xcframework"
 
 
 

--- a/src/Xcode/DWARF.hs
+++ b/src/Xcode/DWARF.hs
@@ -54,11 +54,11 @@ data DwarfUUID = DwarfUUID { _uuid :: String
 
 -- Functions
 
--- | Attempts to get UUIDs of DWARFs form a .framework/<binary-name> or .dSYM
+-- | Attempts to get UUIDs of DWARFs form a .xcframework/<binary-name> or .dSYM
 -- | by running `xcrun dwarfdump --uuid <path>`
 dwarfUUIDsFrom
   :: MonadIO m
-  => FilePath -- ^ Path to dSYM or .framework/<binary-name>
+  => FilePath -- ^ Path to dSYM or .xcframework/<binary-name>
   -> ExceptT String m [DwarfUUID]
 dwarfUUIDsFrom fPath = do
   (exitCode, stdOutText, stdErrText) <- Turtle.procStrictWithErr "xcrun"
@@ -71,7 +71,7 @@ dwarfUUIDsFrom fPath = do
   where errorMessageHeader = "Failed parsing DWARF UUID: "
 
 -- | Parses a DwarfUUID from a string like
---   UUID: EDF2AE8A-2EB4-3CA0-986F-D3E49D8C675F (i386) Carthage/Build/iOS/Alamofire.framework/Alamofire
+--   UUID: EDF2AE8A-2EB4-3CA0-986F-D3E49D8C675F (i386) Carthage/Build/iOS/Alamofire.xcframework/Alamofire
 parseDwarfdumpUUID :: Parsec.Parsec String () DwarfUUID
 parseDwarfdumpUUID = do
   uuid <- Parsec.string "UUID:" >> Parsec.spaces >> Parsec.manyTill (Parsec.hexDigit <|> Parsec.char '-') Parsec.space


### PR DESCRIPTION
## INCOMPLETE PR

Partially updates Rome to use XCFrameworks, which are the new Apple-supported way to distribute binary libraries on Apple's platforms. This is to test operations with the new Carthage that produces XCFrameworks (.xcframework) instead of Frameworks (.framework).

**However, I realized after making this PR that we also need to completely refactor the logic of how platform-specific cacheing is handled, since XCFrameworks are themselves, multi-platform.** 

Since I'm new to Haskell, this may take me awhile. Any help in this regard would me most helpful.

As well, Rome's CI scripts to validate Rome appear to be based on AFNetworking.framework being a .framework so I'm not sure how I would ensure that AFNetworking is a .xcframework. Please advise.

## Rationale

Unlike .frameworks, XCFrameworks do not have to be recompiled to work with newer versions of Xcode/Swfit. They are also cross-platform and multi-architecture, obviating the need to "lipo" out other architectures before adding the framework to a bundle. That means they play nice with Xcode playgrounds and simulators on M1-based Macs.

.frameworks are no longer supported going forwards by Apple so this is a needed change.

This PR should address https://github.com/tmspzz/Rome/issues/238