### PR TITLE
Add Support for XCFrameworks

### DIFF
--- a/src/Caches/Local/Probing.hs
+++ b/src/Caches/Local/Probing.hs
@@ -16,13 +16,14 @@ probeLocalCacheForFrameworks
   :: MonadIO m
   => FilePath -- ^ The cache definition.
   -> CachePrefix -- ^ A prefix for folders at top level in the cache.
+  -> Bool -- ^ useXcFrameworks
   -> InvertedRepositoryMap -- ^ The map used to resolve `FrameworkName`s to `GitRepoName`s.
   -> [FrameworkVersion] -- ^ A list of `FrameworkVersion` to probe for.
   -> [TargetPlatform] -- ^ A list target platforms restricting the scope of this action.
   -> m [FrameworkAvailability]
-probeLocalCacheForFrameworks lCacheDir cachePrefix reverseRomeMap frameworkVersions = sequence . probeForEachFramework
+probeLocalCacheForFrameworks lCacheDir cachePrefix useXcFrameworks reverseRomeMap frameworkVersions = sequence . probeForEachFramework
  where
-  probeForEachFramework = mapM (probeLocalCacheForFramework lCacheDir cachePrefix reverseRomeMap) frameworkVersions
+  probeForEachFramework = mapM (probeLocalCacheForFramework lCacheDir cachePrefix useXcFrameworks reverseRomeMap) frameworkVersions
 
 
 
@@ -31,16 +32,17 @@ probeLocalCacheForFramework
   :: MonadIO m
   => FilePath -- ^ The cache definition.
   -> CachePrefix -- ^ A prefix for folders at top level in the cache.
+  -> Bool -- ^ useXcFrameworks
   -> InvertedRepositoryMap -- ^ The map used to resolve `FrameworkName`s to `GitRepoName`s.
   -> FrameworkVersion -- ^ The `FrameworkVersion` to probe for.
   -> [TargetPlatform] -- ^ A list target platforms restricting the scope of this action.
   -> m FrameworkAvailability
-probeLocalCacheForFramework lCacheDir cachePrefix reverseRomeMap frameworkVersion platforms = fmap
+probeLocalCacheForFramework lCacheDir cachePrefix useXcFrameworks reverseRomeMap frameworkVersion platforms = fmap
   (FrameworkAvailability frameworkVersion)
   probeForEachPlatform
  where
   probeForEachPlatform = mapM
-    (probeLocalCacheForFrameworkOnPlatform lCacheDir cachePrefix reverseRomeMap frameworkVersion)
+    (probeLocalCacheForFrameworkOnPlatform lCacheDir cachePrefix useXcFrameworks reverseRomeMap frameworkVersion)
     (platforms `intersect` (_frameworkPlatforms . _framework $ frameworkVersion))
 
 
@@ -50,14 +52,15 @@ probeLocalCacheForFrameworkOnPlatform
   :: MonadIO m
   => FilePath -- ^ The cache definition.
   -> CachePrefix -- ^ A prefix for folders at top level in the cache.
+  -> Bool -- ^ useXcFrameworks
   -> InvertedRepositoryMap -- ^ The map used to resolve `FrameworkName`s to `GitRepoName`s.
   -> FrameworkVersion -- ^ The `FrameworkVersion` to probe for.
   -> TargetPlatform -- ^ A target platforms restricting the scope of this action.
   -> m PlatformAvailability
-probeLocalCacheForFrameworkOnPlatform lCacheDir (CachePrefix prefix) reverseRomeMap (FrameworkVersion fwn version) platform
+probeLocalCacheForFrameworkOnPlatform lCacheDir (CachePrefix prefix) useXcFrameworks reverseRomeMap (FrameworkVersion fwn version) platform
   = do
     frameworkExistsInLocalCache <- liftIO . doesFileExist $ frameworkLocalCachePath
     return (PlatformAvailability platform frameworkExistsInLocalCache)
  where
   frameworkLocalCachePath   = lCacheDir </> prefix </> remoteFrameworkUploadPath
-  remoteFrameworkUploadPath = remoteFrameworkPath platform reverseRomeMap fwn version
+  remoteFrameworkUploadPath = remoteFrameworkPath useXcFrameworks platform reverseRomeMap fwn version

--- a/src/Caches/Local/Uploading.hs
+++ b/src/Caches/Local/Uploading.hs
@@ -28,11 +28,12 @@ import           Xcode.DWARF
 saveFrameworkToLocalCache
   :: FilePath -- ^ The cache definition.
   -> Zip.Archive -- ^ The zipped archive of the Framework
+  -> Bool -- ^ useXcFrameworks
   -> InvertedRepositoryMap -- ^ The map used to resolve `FrameworkName`s to `GitRepoName`s.
   -> FrameworkVersion -- ^ The `FrameworkVersion` identifying the dSYM.
   -> TargetPlatform -- ^ A `TargetPlatform` to limit the operation to.
   -> ReaderT (CachePrefix, SkipLocalCacheFlag, Bool) IO ()
-saveFrameworkToLocalCache lCacheDir frameworkArchive reverseRomeMap (FrameworkVersion f@(Framework _ _ fwps) version) platform
+saveFrameworkToLocalCache lCacheDir frameworkArchive useXcFrameworks reverseRomeMap (FrameworkVersion f@(Framework _ _ fwps) version) platform
   = when (platform `elem` fwps) $ do
     (CachePrefix prefix, SkipLocalCacheFlag skipLocalCache, verbose) <- ask
     unless skipLocalCache $ saveBinaryToLocalCache lCacheDir
@@ -41,7 +42,7 @@ saveFrameworkToLocalCache lCacheDir frameworkArchive reverseRomeMap (FrameworkVe
                                                    frameworkNameWithFrameworkExtension
                                                    verbose
  where
-  remoteFrameworkUploadPath           = remoteFrameworkPath platform reverseRomeMap f version
+  remoteFrameworkUploadPath           = remoteFrameworkPath useXcFrameworks platform reverseRomeMap f version
   frameworkNameWithFrameworkExtension = appendFrameworkExtensionTo f
 
 

--- a/src/Caches/S3/Probing.hs
+++ b/src/Caches/S3/Probing.hs
@@ -20,28 +20,30 @@ import           Utils
 -- | in the caches for each `TargetPlatform`
 probeS3ForFrameworks
   :: S3.BucketName -- ^ The cache definition.
+  -> Bool -- ^ useXcFrameworks
   -> InvertedRepositoryMap -- ^ The map used to resolve `FrameworkName`s to `GitRepoName`s.
   -> [FrameworkVersion] -- ^ A list of `FrameworkVersion` to probe for.
   -> [TargetPlatform] -- ^ A list target platforms restricting the scope of this action.
   -> ReaderT (AWS.Env, CachePrefix, Bool) IO [FrameworkAvailability]
-probeS3ForFrameworks s3BucketName reverseRomeMap frameworkVersions platforms = mapConcurrently probe frameworkVersions
-  where probe fVersions = probeS3ForFramework s3BucketName reverseRomeMap fVersions platforms
+probeS3ForFrameworks s3BucketName useXcFrameworks reverseRomeMap frameworkVersions platforms = mapConcurrently probe frameworkVersions
+  where probe fVersions = probeS3ForFramework s3BucketName useXcFrameworks reverseRomeMap fVersions platforms
 
 
 
 -- | Probes the caches described by `RomeCacheInfo` to check whether a `FrameworkVersion` is present or not in each `TargetPlatform`
 probeS3ForFramework
   :: S3.BucketName -- ^ The cache definition.
+  -> Bool -- ^ useXcFrameworks
   -> InvertedRepositoryMap -- ^ The map used to resolve `FrameworkName`s to `GitRepoName`s.
   -> FrameworkVersion -- ^ The `FrameworkVersion` to probe for.
   -> [TargetPlatform] -- ^ A list target platforms restricting the scope of this action.
   -> ReaderT (AWS.Env, CachePrefix, Bool) IO FrameworkAvailability
-probeS3ForFramework s3BucketName reverseRomeMap frameworkVersion platforms = fmap
+probeS3ForFramework s3BucketName useXcFrameworks reverseRomeMap frameworkVersion platforms = fmap
   (FrameworkAvailability frameworkVersion)
   probeForEachPlatform
  where
   probeForEachPlatform = mapConcurrently
-    (probeS3ForFrameworkOnPlatform s3BucketName reverseRomeMap frameworkVersion)
+    (probeS3ForFrameworkOnPlatform s3BucketName useXcFrameworks reverseRomeMap frameworkVersion)
     (platforms `intersect` (_frameworkPlatforms . _framework $ frameworkVersion))
 
 
@@ -49,11 +51,12 @@ probeS3ForFramework s3BucketName reverseRomeMap frameworkVersion platforms = fma
 -- | Probes the caches described by `RomeCacheInfo` to check whether a `FrameworkVersion` is present or not for a `TargetPlatform`.
 probeS3ForFrameworkOnPlatform
   :: S3.BucketName -- ^ The cache definition.
+  -> Bool -- ^ useXcFrameworks
   -> InvertedRepositoryMap -- ^ The map used to resolve `FrameworkName`s to `GitRepoName`s.
   -> FrameworkVersion -- ^ The `FrameworkVersion` to probe for.
   -> TargetPlatform -- ^ A target platforms restricting the scope of this action.
   -> ReaderT (AWS.Env, CachePrefix, Bool) IO PlatformAvailability
-probeS3ForFrameworkOnPlatform s3BucketName reverseRomeMap (FrameworkVersion fwn v) platform = do
+probeS3ForFrameworkOnPlatform s3BucketName useXcFrameworks reverseRomeMap (FrameworkVersion fwn v) platform = do
   (env, CachePrefix prefixStr, _) <- ask
   let isAvailable = AWS.runResourceT . AWS.runAWS env $ checkIfFrameworkExistsInBucket
         s3BucketName
@@ -61,7 +64,7 @@ probeS3ForFrameworkOnPlatform s3BucketName reverseRomeMap (FrameworkVersion fwn 
   PlatformAvailability platform <$> isAvailable
  where
   frameworkObjectKeyWithPrefix cPrefix =
-    S3.ObjectKey . T.pack $ cPrefix </> remoteFrameworkPath platform reverseRomeMap fwn v
+    S3.ObjectKey . T.pack $ cPrefix </> remoteFrameworkPath useXcFrameworks platform reverseRomeMap fwn v
 
 
 

--- a/src/Caches/S3/Uploading.hs
+++ b/src/Caches/S3/Uploading.hs
@@ -24,16 +24,17 @@ import           Xcode.DWARF
 uploadFrameworkToS3
   :: Zip.Archive -- ^ The `Zip.Archive` of the Framework.
   -> S3.BucketName -- ^ The cache definition.
+  -> Bool -- ^ useXcFrameworks
   -> InvertedRepositoryMap -- ^ The map used to resolve `FrameworkName`s to `GitRepoName`s.
   -> FrameworkVersion -- ^ The `FrameworkVersion` identifying the Framework.
   -> TargetPlatform -- ^ A `TargetPlatform`s restricting the scope of this action.
   -> ReaderT UploadDownloadEnv IO ()
-uploadFrameworkToS3 frameworkArchive s3BucketName reverseRomeMap (FrameworkVersion f@(Framework fwn _ fwps) version) platform
+uploadFrameworkToS3 frameworkArchive s3BucketName useXcFrameworks reverseRomeMap (FrameworkVersion f@(Framework fwn _ fwps) version) platform
   = when (platform `elem` fwps) $ do
     (env, CachePrefix prefix, verbose) <- ask
     withReaderT (const (env, verbose))
       $ uploadBinary s3BucketName (Zip.fromArchive frameworkArchive) (prefix </> remoteFrameworkUploadPath) fwn
-  where remoteFrameworkUploadPath = remoteFrameworkPath platform reverseRomeMap f version
+  where remoteFrameworkUploadPath = remoteFrameworkPath useXcFrameworks platform reverseRomeMap f version
 
 
 

--- a/src/CommandParsers.hs
+++ b/src/CommandParsers.hs
@@ -43,6 +43,12 @@ noSkipCurrentParser = NoSkipCurrentFlag <$> Opts.switch
   <> Opts.help "Do not skip the `currentMap` section in the Romefile when performing the operation."
   )
 
+useXcFrameworksParser :: Opts.Parser UseXcFrameworksFlag
+useXcFrameworksParser = UseXcFrameworksFlag <$> Opts.switch
+  (  Opts.long "use-xcframeworks"
+  <> Opts.help "Search for .xcframeworks when performing the operation."
+  )
+
 concurrentlyParser :: Opts.Parser ConcurrentlyFlag
 concurrentlyParser = ConcurrentlyFlag <$> Opts.switch
   (  Opts.long "concurrently"
@@ -85,6 +91,7 @@ udcPayloadParser =
     <*> skipLocalCacheParser
     <*> noIgnoreParser
     <*> noSkipCurrentParser
+    <*> useXcFrameworksParser
     <*> concurrentlyParser
 
 uploadParser :: Opts.Parser RomeCommand
@@ -116,6 +123,7 @@ listPayloadParser =
     <*> printFormatParser
     <*> noIgnoreParser
     <*> noSkipCurrentParser
+    <*> useXcFrameworksParser
 
 listParser :: Opts.Parser RomeCommand
 listParser = List <$> listPayloadParser

--- a/src/Engine/Uploading.hs
+++ b/src/Engine/Uploading.hs
@@ -24,16 +24,17 @@ import qualified Turtle
 uploadFrameworkToEngine
   :: Zip.Archive -- ^ The `Zip.Archive` of the Framework.
   -> FilePath -- ^ The `FilePath` to the engine.
+  -> Bool -- ^ useXcFrameworks
   -> InvertedRepositoryMap -- ^ The map used to resolve `FrameworkName`s to `GitRepoName`s.
   -> FrameworkVersion -- ^ The `FrameworkVersion` identifying the Framework.
   -> TargetPlatform -- ^ A `TargetPlatform`s restricting the scope of this action.
   -> ReaderT (CachePrefix, Bool) IO ()
-uploadFrameworkToEngine frameworkArchive enginePath reverseRomeMap (FrameworkVersion f@(Framework fwn _ fwps) version) platform
+uploadFrameworkToEngine frameworkArchive enginePath useXcFrameworks reverseRomeMap (FrameworkVersion f@(Framework fwn _ fwps) version) platform
   = when (platform `elem` fwps) $ do
     (CachePrefix prefix, verbose) <- ask
     withReaderT (const verbose)
       $ uploadBinary enginePath (Zip.fromArchive frameworkArchive) (prefix </> remoteFrameworkUploadPath) fwn
-  where remoteFrameworkUploadPath = remoteFrameworkPath platform reverseRomeMap f version
+  where remoteFrameworkUploadPath = remoteFrameworkPath useXcFrameworks platform reverseRomeMap f version
 
 
 

--- a/src/Types/Commands.hs
+++ b/src/Types/Commands.hs
@@ -11,14 +11,15 @@ data RomeCommand = Upload RomeUDCPayload
 
 
 
-data RomeUDCPayload = RomeUDCPayload { _payload            :: [ProjectName]
-                                     , _udcPlatforms       :: [TargetPlatform]
-                                     , _cachePrefix        :: String
+data RomeUDCPayload = RomeUDCPayload { _payload              :: [ProjectName]
+                                     , _udcPlatforms         :: [TargetPlatform]
+                                     , _cachePrefix          :: String
                                     --  , _verifyFlag         :: VerifyFlag
-                                     , _skipLocalCacheFlag :: SkipLocalCacheFlag
-                                     , _noIgnoreFlag       :: NoIgnoreFlag
-                                     , _noSkipCurrentFlag  :: NoSkipCurrentFlag
-                                     , _concurrentlyFlag   :: ConcurrentlyFlag
+                                     , _skipLocalCacheFlag   :: SkipLocalCacheFlag
+                                     , _noIgnoreFlag         :: NoIgnoreFlag
+                                     , _noSkipCurrentFlag    :: NoSkipCurrentFlag
+                                     , _useXcFrameworksFlag  :: UseXcFrameworksFlag
+                                     , _concurrentlyFlag     :: ConcurrentlyFlag
                                      }
                                      deriving (Show, Eq)
 
@@ -40,15 +41,19 @@ newtype NoIgnoreFlag = NoIgnoreFlag { _noIgnore :: Bool }
 newtype NoSkipCurrentFlag = NoSkipCurrentFlag { _noSkipCurrent :: Bool }
                                               deriving (Show, Eq)
 
+newtype UseXcFrameworksFlag = UseXcFrameworksFlag { _useXcFrameworks :: Bool }
+                                              deriving (Show, Eq)
+
 newtype ConcurrentlyFlag = ConcurrentlyFlag { _concurrently :: Bool }
                                               deriving (Show, Eq)
 
-data RomeListPayload = RomeListPayload { _listMode              :: ListMode
-                                       , _listPlatforms         :: [TargetPlatform]
-                                       , _listCachePrefix       :: String
-                                       , _listFormat            :: PrintFormat
-                                       , _listNoIgnoreFlag      :: NoIgnoreFlag
-                                       , _listNoSkipCurrentFlag :: NoSkipCurrentFlag
+data RomeListPayload = RomeListPayload { _listMode                  :: ListMode
+                                       , _listPlatforms             :: [TargetPlatform]
+                                       , _listCachePrefix           :: String
+                                       , _listFormat                :: PrintFormat
+                                       , _listNoIgnoreFlag          :: NoIgnoreFlag
+                                       , _listNoSkipCurrentFlag     :: NoSkipCurrentFlag
+                                       , _listUseXcFrameworksFlag   :: UseXcFrameworksFlag
                                        }
                                        deriving (Show, Eq)
 

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -69,6 +69,7 @@ import           System.FilePath                ( addTrailingPathSeparator
 import           Text.Read                      ( readMaybe )
 import qualified Turtle
 import           Types
+import           Types.Commands
 import           Xcode.DWARF                    ( DwarfUUID
                                                 , bcsymbolmapNameFrom
                                                 )
@@ -166,11 +167,20 @@ appendFrameworkExtensionTo (Framework a _ _) = a ++ ".framework"
 
 
 
+-- | Appends the string ".xcframework" to a `XCFramework`'s name.
+appendXcFrameworkExtensionTo :: Framework -> String
+appendXcFrameworkExtensionTo (Framework a _ _) = a ++ ".xcframework"
+
+
+
 -- | Given a `Framework` and a `Version` produces a name for a Zip archive.
-frameworkArchiveName :: Framework -> Version -> String
-frameworkArchiveName f@(Framework _ Dynamic _) (Version v) = appendFrameworkExtensionTo f ++ "-" ++ v ++ ".zip"
-frameworkArchiveName f@(Framework _ Static _) (Version v) =
-  appendFrameworkExtensionTo f ++ "-" ++ "static" ++ "-" ++ v ++ ".zip"
+frameworkArchiveName :: Framework -> Version -> Bool -> String
+frameworkArchiveName f@(Framework _ Dynamic _) (Version v) x =
+  if x then appendXcFrameworkExtensionTo f ++ "-" ++ v ++ ".zip"
+  else appendFrameworkExtensionTo f ++ "-" ++ v ++ ".zip"
+frameworkArchiveName f@(Framework _ Static _) (Version v) x =
+  if x then appendXcFrameworkExtensionTo f ++ "-" ++ "static" ++ "-" ++ v ++ ".zip"
+  else appendFrameworkExtensionTo f ++ "-" ++ "static" ++ "-" ++ v ++ ".zip"
 
 
 
@@ -279,8 +289,8 @@ filterRomeFileEntriesByPlatforms lhs rhs = (uncurry RomefileEntry <$>) . M.toLis
 
 
 -- | Builds a string representing the remote path to a framework zip archive.
-remoteFrameworkPath :: TargetPlatform -> InvertedRepositoryMap -> Framework -> Version -> String
-remoteFrameworkPath p r f v = remoteCacheDirectory p r f ++ frameworkArchiveName f v
+remoteFrameworkPath :: Bool -> TargetPlatform -> InvertedRepositoryMap -> Framework -> Version -> String
+remoteFrameworkPath x p r f v = remoteCacheDirectory p r f ++ frameworkArchiveName f v x
 
 
 


### PR DESCRIPTION
Addresses #238 

A first pass at adding XCFramework support to Rome. This is my first time writing an Haskell so please be kind. This is not a complete implementation, but it's in a place where it's usable. I'd love if someone could pick this up and bring it across the finish line. Or even point me in the right direction.

## Changes
- Added a `--use-xcframeworks` flag to the `upload`, `download`, and `list` commands

## Known Issues
- Running with `--use-xcframeworks` and a `--platform` ignores frameworks that aren't xcframeworks (workaround is to run it twice with and without the use xcframeworks option)
- Running with `--use-xcframeworks` and a `--platform` places all frameworks inside a platform specific folder in the cache


P.S: We love Rome at The Knot. It's undoubtedly saved us hundreds of developer hours in the two years we've been using it. Thank you so much for building such a useful tool.