### PR TITLE
Prefer Homebrew's official formula

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,7 @@ Trusted by:
 ## Get Rome
 ### Using Homebrew
 ```
-$ brew tap tmspzz/tap https://github.com/tmspzz/homebrew-tap.git
-$ brew install tmspzz/homebrew-tap/rome
+$ brew install rome
 ```
 ### Using CocoaPods
 Simply add the following line to your Podfile:


### PR DESCRIPTION
I registered Rome to Homebrew's official repository, and now everyone can install Rome without tapping.
https://github.com/Homebrew/homebrew-core/pull/112033

In addition, ARM64 native binary and Linux are supported because Homebrew requires this.

https://github.com/Homebrew/homebrew-core/blob/master/Formula/rome.rb